### PR TITLE
Fix Code Trimmed Issue

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -41,7 +41,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  browser = await launch({ userDataDir: ROOT_PATH + '/data', headless: true });
+  browser = await launch({ userDataDir: ROOT_PATH + '/data', headless: true, defaultViewport: null, args: ['--window-size=1,1'] });
 
   if (CHECK_IS_LOGGED_IN) {
     const loggedIn = await isLoggedIn();
@@ -204,8 +204,8 @@ async function downloadPage(title: string, link: string, doToggleMenu: boolean):
     await setTimeoutPromise(300); // Wait for munu to close
 
     await page.screenshot({ path: `${SAVE_DESTINATION}/${normalizedTitle}.png`, fullPage: true });
-    await page.close();
   }
+  await page.close();
 }
 
 async function login(): Promise<void> {


### PR DESCRIPTION
The issue with [Moanco](https://microsoft.github.io/monaco-editor/) is that it loads up the stylesheet when the code editor is visible and then our MHTML format is not able to capture code which is scrollable inside that. To fix this, we can reduce the size of chromium to just 1px to always ensure that the code block will always be down of current visible area. Also added logic to close the page once the screenshot, pdf or html file is generated.