### PR TITLE
Fix login failed issue

### DIFF
--- a/src/login.ts
+++ b/src/login.ts
@@ -68,7 +68,7 @@ export async function login(): Promise<void> {
   await page.type('[name=email]', EMAIL, { delay: 200 });
   await page.type('[name=password]', PASSWORD, { delay: 200 });
 
-  const clickLoginBtn = await clickButton(page, 'MuiButton-label', 'LOGIN');
+  const clickLoginBtn = await clickButton(page, 'MuiButton-label', 'Login');
 
   if (!clickLoginBtn) {
     throw new Error('Could not find login button (login form submit)');


### PR DESCRIPTION
**Reason:**
Educative.IO renamed the Login button from "LOGIN" to "Login". The script could not find the DOM Node matching "Login". That is why login was failing.